### PR TITLE
候補者詳細ページ作成(後編)

### DIFF
--- a/app/assets/stylesheets/organisms/detail-block.sass
+++ b/app/assets/stylesheets/organisms/detail-block.sass
@@ -1,0 +1,10 @@
+.candidate-detail-wrapper
+  margin: 0 80px
+  .detail-item
+    margin-bottom: 50px
+    &:first-child
+      margin-top: 50px
+    p.typo-text-1
+      margin-bottom: 5px
+    p.typo-2
+      margin-top: 5px

--- a/app/assets/stylesheets/organisms/person-block.sass
+++ b/app/assets/stylesheets/organisms/person-block.sass
@@ -1,5 +1,5 @@
 .person-block
-  width: 1024px
+  width: 100%
   height: 380px
   background-color: #F2F2F2
   display: flex

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -20,4 +20,7 @@ class Candidate < ApplicationRecord
   def full_name_furigana
   	"#{self.name_last} #{self.name_first}"
   end
+  def birth_day_to_jp
+    "#{self.birth_day.strftime("%Y年%m月%d日")}"
+  end
 end

--- a/app/views/candidates/show.html.erb
+++ b/app/views/candidates/show.html.erb
@@ -1,3 +1,35 @@
-<h2>候補者</h2>
+<%= render partial:'layouts/organisms/person-block',
+locals: {
+    party: @candidate.party,
+    name: @candidate.full_name,
+    age: @candidate.age("歳"),
+    job: '前職',
+    image: '/assets/Person@2x.png',
+    areaType: '比',
+    facebookLink: '',
+    instagramLink: '',
+    internetLink: '',
+    lineLink: '',
+    twitterLink: '',
+    wikipediaLink: '',
+    youtubeLink: ''
+} %>
+<%= render partial:'layouts/organisms/detail-block',
+locals: {
+    name: @candidate.full_name,
+    party: @candidate.party,
+    recommendationParty: '推薦政党が入ります',
+    previousParty: '以前の政党が入ります',
+    job: '前職',
+    candidacyHistory: '過去の立候補歴',
+    sex: '男性',
+    birthDay: @candidate.birth_day_to_jp,
+    birthPlace: '出生地',
+    latestEducationalBackground: '最新の学歴が入ります',
+    educationalBackground: '学歴の履歴が入ります',
+    career: '職歴',
+    publicOffice: '公職',
+    father: '父親',
+    mate: '配偶者'
+} %>
 
-<%= @candidate.full_name %>

--- a/app/views/layouts/organisms/_detail-block.html.erb
+++ b/app/views/layouts/organisms/_detail-block.html.erb
@@ -1,0 +1,62 @@
+<div class="candidate-detail-wrapper">
+  <div class="detail-item">
+    <p class="typo-text-1">本名</p>
+    <p class="typo-2"><%= name %></p>
+  </div>
+  <div class="detail-item">
+    <p class="typo-text-1">公認政党</p>
+    <p class="typo-2"><%= party %></p>
+  </div>
+  <div class="detail-item">
+    <p class="typo-text-1">推薦政党</p>
+    <p class="typo-2"><%= recommendationParty %></p>
+  </div>
+  <div class="detail-item">
+    <p class="typo-text-1">以前の政党</p>
+    <p class="typo-2"><%= previousParty %></p>
+  </div>
+  <div class="detail-item">
+    <p class="typo-text-1">前職</p>
+    <p class="typo-2"><%= party %></p>
+  </div>
+  <div class="detail-item">
+    <p class="typo-text-1">過去の立候補歴</p>
+    <p class="typo-2"><%= candidacyHistory %></p>
+  </div>
+  <div class="detail-item">
+    <p class="typo-text-1">性別</p>
+    <p class="typo-2"><%= sex %></p>
+  </div>
+  <div class="detail-item">
+    <p class="typo-text-1">生年月日</p>
+    <p class="typo-2"><%= birthDay %></p>
+  </div>
+  <div class="detail-item">
+    <p class="typo-text-1">出生地</p>
+    <p class="typo-2"><%= birthPlace %></p>
+  </div>
+  <div class="detail-item">
+    <p class="typo-text-1">学歴(最新)</p>
+    <p class="typo-2"><%= latestEducationalBackground %></p>
+  </div>
+  <div class="detail-item">
+    <p class="typo-text-1">学歴(履歴)</p>
+    <p class="typo-2"><%= educationalBackground %></p>
+  </div>
+  <div class="detail-item">
+    <p class="typo-text-1">職歴</p>
+    <p class="typo-2"><%= career %></p>
+  </div>
+  <div class="detail-item">
+    <p class="typo-text-1">公職</p>
+    <p class="typo-2"><%= publicOffice %></p>
+  </div>
+  <div class="detail-item">
+    <p class="typo-text-1">父親</p>
+    <p class="typo-2"><%= father %></p>
+  </div>
+  <div class="detail-item">
+    <p class="typo-text-1">配偶者</p>
+    <p class="typo-2"><%= mate %></p>
+  </div>
+</div>

--- a/app/views/layouts/organisms/_person-block.html.erb
+++ b/app/views/layouts/organisms/_person-block.html.erb
@@ -3,7 +3,7 @@
     <div class="typo-text-1"><%= party %> <%= render partial:'layouts/molecules/area-type', locals: {areaType: '比'} %></div>
     <div class="column">
         <div class="typo-1 person-name"><%= name %></div>
-        <div class="typo-text-1 person-age"><%= age %>歳</div>
+        <div class="typo-text-1 person-age"><%= age %></div>
     </div>
     <div class="typo-text-1 former-job"><%= job %></div>
     <%= render partial:'layouts/molecules/social-icons',

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -66,3 +66,21 @@ locals: {
     wikipediaLink: '/',
     youtubeLink: '/'
 } %>
+<%= render partial:'layouts/organisms/detail-block',
+locals: {
+    name: '山田太郎',
+    party: '甘党',
+    recommendationParty: '推薦政党が入ります',
+    previousParty: '以前の政党が入ります',
+    job: '前職',
+    candidacyHistory: '過去の立候補歴',
+    sex: '男性',
+    birthDay: '1900年1月1日',
+    birthPlace: '出生地',
+    latestEducationalBackground: '最新の学歴が入ります',
+    educationalBackground: '学歴の履歴が入ります',
+    career: '職歴',
+    publicOffice: '公職',
+    father: '父親',
+    mate: '配偶者'
+} %>


### PR DESCRIPTION
## やったこと
- 候補者詳細ページの作成
  - person blockコンポーネントの組み込み
  - 候補者詳細コンポーネントの作成および組み込み
  - 候補者のデータが表示されるように
## 懸念点
- データほとんどとれていない
- 政党名がうまく表示されない
## スクリーンショット
[![Screenshot from Gyazo](https://gyazo.com/a5d7382c98fbac828d8da415cf26aa27/raw)](https://gyazo.com/a5d7382c98fbac828d8da415cf26aa27)