### PR TITLE
候補者名で検索機能を追加

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -15,11 +15,28 @@ class SearchController < ApplicationController
     @title = "#{@senkyoku.name}の候補者一覧"
   end
 
+  def by_name
+    @keyword = params[:keyword]
+    tokens = @keyword.scan(/\p{hiragana}+|\p{katakana}+|\p{Han}+|[A-Za-z]+/)
+    last_like = like_escape(tokens.first || '') + '%'
+    first_like = like_escape((tokens[1..-1] || []).join('')) + '%'
+
+    @candidates = Candidate.where(
+      '(name_last LIKE ? OR name_last_furigana LIKE ?)' +
+      ' AND (name_first LIKE ? OR name_first_furigana LIKE ?)',
+      last_like, last_like, first_like, first_like
+    ).order('submission_order ASC').limit(100).to_a
+  end
 
   private
     # Never trust parameters from the scary internet, only allow the white list through.
     def search_params
       params.permit(:zip_code)
+    end
+
+    def like_escape(str)
+      # http://d.hatena.ne.jp/teracc/20090703/1246576620
+      str.gsub(/([\\%_])/, '\\\\\\1')
     end
 
 end

--- a/app/views/layouts/molecules/_searchbar_by_name.html.erb
+++ b/app/views/layouts/molecules/_searchbar_by_name.html.erb
@@ -1,0 +1,10 @@
+<div class="search-bar">
+    <form action="/search_by_name", method="get">
+        <input type="text"
+            name="<%= :keyword %>"
+            class="typo-2"
+            placeholder="候補者名を入力してください"
+        />
+        <input type="image" value=" " class="fa fa-search"/>
+    </form>
+</div>

--- a/app/views/search/_candidate.html.erb
+++ b/app/views/search/_candidate.html.erb
@@ -1,0 +1,10 @@
+<%= render 'layouts/organisms/person-item',
+  party: candidate.party.try(:short_name) || "無所属",
+  name: candidate.full_name,
+  age: candidate.age("歳"),
+  job: candidate.current_position_label,
+  areaType: nil,
+  isHirei: candidate.is_hirei_label,
+  image: asset_path('Person@2x.png'),
+  detailUrl: candidate_path(id: candidate.wikidata_id)
+%>

--- a/app/views/search/by_name.html.erb
+++ b/app/views/search/by_name.html.erb
@@ -1,0 +1,10 @@
+<%= render :partial=>'layouts/organisms/list-header', :locals=>{ senkyokuName: "#{@keyword}の検索結果" } %>
+
+<% if @candidates.empty? %>
+  <p>入力された名前では候補者は見つかりませんでした</p>
+<% else %>
+  <div class="candidate-wrapper">
+    <!-- Real candidate data -->
+    <%= render partial: 'candidate', collection: @candidates %>
+  </div>
+<% end %>

--- a/app/views/search/new.html.erb
+++ b/app/views/search/new.html.erb
@@ -6,9 +6,14 @@
   全ての候補者の情報は、中立的な立場で収集した事実情報に基いています。
 </div>
 
-<h1>検索</h1>
+<h1>郵便番号で検索</h1>
 <div>
 <%= render partial:'layouts/molecules/searchbar'%>
+</div>
+
+<h1>候補者名で検索</h1>
+<div>
+<%= render partial:'layouts/molecules/searchbar_by_name'%>
 </div>
 
 <h1>都道府県別</h1>

--- a/app/views/search/show.html.erb
+++ b/app/views/search/show.html.erb
@@ -3,19 +3,7 @@
 <% if @senkyoku.present? %>
   <div class="candidate-wrapper">
     <!-- Real candidate data -->
-    <% @senkyoku.candidates.order('submission_order ASC').each do | candidate | %>
-      <%= render 'layouts/organisms/person-item',
-        party: candidate.party.try(:short_name) || "無所属",
-        name: candidate.full_name,
-        age: candidate.age("歳"),
-        job: candidate.current_position_label,
-        areaType: nil,
-        isHirei: candidate.is_hirei_label,
-        image: asset_path('Person@2x.png'),
-        detailUrl: candidate_path(id: candidate.wikidata_id)
-      %>
-    <% end %>
-
+    <%= render partial: 'candidate', collection: @senkyoku.candidates.order('submission_order ASC') %>
   </div>
 <% else %>
   <p>入力された郵便番号では選挙区は見つかりませんでした</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   root to: "search#new"
   get "/search", to: "search#show"
+  get "/search_by_name", to: "search#by_name"
   get '/senkyoku/:pref_code', to: 'prefs#show'
   get '/senkyoku/:pref_code/:senkyoku_no', to: 'senkyokus#show'
 


### PR DESCRIPTION
Closes #64

https://github.com/codeforjapan/codeforelection_front/issues/64#issuecomment-336172641
この前後での議論に合わせて、漢字、ひらがな、カタカナと言った文字種に応じてトークンに分割し、下記の条件に応じて検索します。
- トークンが2つ以上の場合：1つ目のトークンは名字に、かつ残りのトークンは名前に前方一致する候補者を検索
- トークンが2つ未満の場合：名字か名前のどちらかが入力文字列に前方一致する候補者を検索

現在のところ `安倍 晋三` はヒットするものの、 `安倍晋三` ではヒットしません。
https://github.com/codeforjapan/codeforelection_front/issues/64#issuecomment-336168335
また、 `より子` と入力された場合、名字 `より` 、名前 `子` で検索してしまうため `円 より子` にヒットしません。
https://github.com/codeforjapan/codeforelection_front/issues/64#issuecomment-336180463
現在の実装方針で問題なければname_full / name_full_furiganaカラムを追加して、スペースなしのフルネームや `より子` が入力されても検索できるようにします・・！

（ransackは複数条件の制御が面倒だった記憶があったので避けてみました）