### PR TITLE
候補者名検索をフルネームに対応

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -16,14 +16,17 @@ class SearchController < ApplicationController
   def by_name
     @keyword = params[:keyword]
     tokens = @keyword.scan(/\p{hiragana}+|\p{katakana}+|\p{Han}+|[A-Za-z]+/)
-    last_like = like_escape(tokens.first || '') + '%'
-    first_like = like_escape((tokens[1..-1] || []).join('')) + '%'
+    last_name = tokens.first || ''
+    first_name = (tokens[1..-1] || []).join('')
 
-    @candidates = Candidate.where(
-      '(name_last LIKE ? OR name_last_furigana LIKE ?)' +
-      ' AND (name_first LIKE ? OR name_first_furigana LIKE ?)',
-      last_like, last_like, first_like, first_like
-    ).order('submission_order ASC').limit(100).to_a
+    if @keyword.blank?
+      query = Candidate.all
+    elsif first_name.blank?
+      query = Candidate.single_name_search(last_name)
+    else
+      query = Candidate.pair_name_search(last_name, first_name)
+    end
+    @candidates = query.order('submission_order ASC').limit(100).to_a
 
     @title = "#{@keyword}の検索結果一覧"
   end
@@ -32,11 +35,6 @@ class SearchController < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def search_params
       params.permit(:zip_code)
-    end
-
-    def like_escape(str)
-      # http://d.hatena.ne.jp/teracc/20090703/1246576620
-      str.gsub(/([\\%_])/, '\\\\\\1')
     end
 
 end


### PR DESCRIPTION
#85 で実装した候補者名検索は、スペースなしでフルネームで検索するとヒットしない問題があったので、修正しました。
↓で書いていた内容だとカラム追加が必要っぽいこと書いていましたが、`CONCAT()` することでカラム追加無しで実現してます（ただし性能は微妙かもしれない）。
https://github.com/codeforjapan/codeforelection_front/issues/64#issuecomment-336168335

この結果、 `安倍晋三` と入力されたときにヒットしない問題が解消しました。
また `より子` が入力されたときに `円 より子` にヒットするように、（下の）名前だけでも検索するように工夫しています。