### PR TITLE
fix link to database.csv download link.

### DIFF
--- a/app/views/static/data.html.erb
+++ b/app/views/static/data.html.erb
@@ -14,7 +14,7 @@ locals: {
 <p>
   本サイトのデータは、以下のリンクからダウンロードして利用することができます。<br/>
   <h3 class="type-1">候補者データ</h3>
-  <a href="/download.csv">候補者データダウンロード</a>
+  <a href="/database.csv">候補者データダウンロード</a>
   <br/><br/>
   文字コードはUTF8で、以下のデータが含まれています。現在、全てデータが揃っているものと、整備中のものがありますのでお気をつけください。<br/>
   <iframe src="https://docs.google.com/spreadsheets/d/e/2PACX-1vQXiJhHvQExoG3HBpfWnCfAoa_KE_iAdX5OyCOsMn0UGaPjqZQYmjPe3Ic49wYpX357ukb1IXYvk7uU/pubhtml?gid=1748306210&amp;single=true&amp;widget=true&amp;headers=false" width="620" height="300"></iframe>


### PR DESCRIPTION
fix for #151 

database.csv は facebook link の正規化も処理済みです。現在 gray db から直接 rdb に取り込んでいると思いますが、クレンジング済みのものにスイッチするのであれば、要件すり合わせましょう。